### PR TITLE
[FIX] CanvasRenderer constructor

### DIFF
--- a/dist/pixi-tilemap.js
+++ b/dist/pixi-tilemap.js
@@ -843,7 +843,7 @@ var pixi_tilemap;
             var tempRender = this._tempRender;
             if (!buf) {
                 buf = this.canvasBuffer = document.createElement('canvas');
-                tempRender = this._tempRender = new PIXI.CanvasRenderer(100, 100, { view: buf });
+                tempRender = this._tempRender = new PIXI.CanvasRenderer({ width: 100, height: 100, view: buf });
                 tempRender.context = tempRender.rootContext;
                 tempRender.plugins.tilemap.dontUseTransform = true;
             }


### PR DESCRIPTION
While updating my game to v5 I noticed this line was still instantiating the CanvasRenderer with the old signature