### PR TITLE
Add alpha blending support (WebGL and Canvas)

### DIFF
--- a/src/CompositeRectTileLayer.ts
+++ b/src/CompositeRectTileLayer.ts
@@ -19,7 +19,6 @@ namespace pixi_tilemap {
         shadowColor = new Float32Array([0.0, 0.0, 0.0, 0.5]);
         _globalMat: PIXI.Matrix = null;
         _lastLayer: RectTileLayer = null;
-        _alpha: number;
 
         texPerChild: number;
 
@@ -30,7 +29,7 @@ namespace pixi_tilemap {
             }
             this.z = this.zIndex = zIndex;
             this.texPerChild = texPerChild || Constant.boundCountPerBuffer * Constant.maxTextures;
-            this._alpha = alpha || 1.0;
+            this.alpha = alpha ?? 1.0;
             if (bitmaps) {
                 this.setBitmaps(bitmaps);
             }
@@ -72,7 +71,7 @@ namespace pixi_tilemap {
 
             if (this.children[childIndex] && (this.children[childIndex] as RectTileLayer).textures) {
                 this._lastLayer = (this.children[childIndex] as RectTileLayer);
-                const tileAlpha = alpha || this._alpha;
+                const tileAlpha = this.worldAlpha * (alpha ?? 1.0);
                 this._lastLayer.addRect(textureId, u, v, x, y, tileWidth, tileHeight, animX, animY, rotate, animWidth, animHeight, tileAlpha);
             } else {
                 this._lastLayer = null;
@@ -106,15 +105,6 @@ namespace pixi_tilemap {
         }
 
         /**
-         * Set the layer alpha. Every tile added to this layer will inherit this alpha value.
-         *
-         * @param {number} alpha Numeric value between 0.0 and 1.0.
-         */
-        setAlpha(alpha: number) {
-            this._alpha = alpha;
-        }
-
-        /**
          * Set an specified alpha to the tile. By default, alpha is inherit from the tile's
          * CompositeRectTileLayer unless it is overridden with this method.
          *
@@ -122,7 +112,7 @@ namespace pixi_tilemap {
          */
         tileAlpha(alpha: number) {
             if (this._lastLayer) {
-                this._lastLayer.tileAlpha(alpha);
+                this._lastLayer.tileAlpha(this.worldAlpha * alpha);
             }
             return this;
         }
@@ -193,7 +183,7 @@ namespace pixi_tilemap {
             }
 
             this._lastLayer = layer;
-            const tileAlpha = alpha || this._alpha;
+            const tileAlpha = this.worldAlpha * (alpha ?? 1.0);
             layer.addRect(ind, texture.frame.x, texture.frame.y, x, y, texture.orig.width, texture.orig.height, animX, animY, texture.rotate, animWidth, animHeight, tileAlpha);
             return this;
         }

--- a/src/RectTileShader.ts
+++ b/src/RectTileShader.ts
@@ -3,6 +3,7 @@ namespace pixi_tilemap {
 varying vec2 vTextureCoord;
 varying vec4 vFrame;
 varying float vTextureId;
+varying float vAlpha;
 uniform vec4 shadowColor;
 uniform sampler2D uSamplers[%count%];
 uniform vec2 uSamplerSize[%count%];
@@ -14,6 +15,7 @@ void main(void){
    vec4 color;
    %forloop%
    gl_FragColor = color;
+   gl_FragColor.rgb *= vAlpha;
 }
 `;
 
@@ -23,6 +25,7 @@ attribute vec2 aTextureCoord;
 attribute vec4 aFrame;
 attribute vec2 aAnim;
 attribute float aTextureId;
+attribute float aAlpha;
 
 uniform mat3 projTransMatrix;
 uniform vec2 animationFrame;
@@ -30,6 +33,7 @@ uniform vec2 animationFrame;
 varying vec2 vTextureCoord;
 varying float vTextureId;
 varying vec4 vFrame;
+varying float vAlpha;
 
 void main(void){
    gl_Position = vec4((projTransMatrix * vec3(aVertexPosition, 1.0)).xy, 0.0, 1.0);
@@ -40,6 +44,7 @@ void main(void){
    vTextureCoord = aTextureCoord + animOffset;
    vFrame = aFrame + vec4(animOffset, animOffset);
    vTextureId = aTextureId;
+   vAlpha = aAlpha;
 }
 `;
 
@@ -69,13 +74,13 @@ void main(void){
 				maxTextures,
 				rectShaderVert,
 				shaderGenerator.generateFragmentSrc(maxTextures, rectShaderFrag)
-			);
+            );
 			shaderGenerator.fillSamplers(this, this.maxTextures);
 		}
 	}
 
 	export class RectTileGeom extends PIXI.Geometry {
-		vertSize = 11;
+		vertSize = 12;
 		vertPerQuad = 4;
 		stride = this.vertSize * 4;
 		lastTimeAccess = 0;
@@ -86,7 +91,8 @@ void main(void){
 				.addAttribute('aTextureCoord', buf, 0, false, 0, this.stride, 2 * 4)
 				.addAttribute('aFrame', buf, 0, false, 0, this.stride, 4 * 4)
 				.addAttribute('aAnim', buf, 0, false, 0, this.stride, 8 * 4)
-				.addAttribute('aTextureId', buf, 0, false, 0, this.stride, 10 * 4);
+                .addAttribute('aTextureId', buf, 0, false, 0, this.stride, 10 * 4)
+                .addAttribute('aAlpha', buf, 0, false, 0, this.stride, 11 * 4);
 		}
 
 		buf: PIXI.Buffer;

--- a/src/RectTileShader.ts
+++ b/src/RectTileShader.ts
@@ -14,8 +14,7 @@ void main(void){
 
    vec4 color;
    %forloop%
-   gl_FragColor = color;
-   gl_FragColor.rgb *= vAlpha;
+   gl_FragColor = (color * vAlpha) + (gl_FragColor * (1.0 - vAlpha));
 }
 `;
 


### PR DESCRIPTION
This pull request adds alpha blending support in both WebGL and Canvas renderers.

The API is pretty straight forward:

 - `CompositeRectTileLayer.alpha = number`: Allows to set the alpha value of the whole layer
 - `RectTileLayer.tileAlpha(number)`: Allows to set the alpha value of a tile, overriding the layer alpha (CompositeRectTileLayer._alpha) value

**Example:**

Replace the content of `basic.js` with the following code for a quick demo:

```
var renderer = PIXI.autoDetectRenderer(800, 600);
document.body.appendChild(renderer.view);

var stage;

var loader = new PIXI.Loader();
loader.add('atlas', 'basic/atlas.json');
loader.add('button', 'basic/button.png');
loader.load(function (loader, resources) {
    stage = new PIXI.Container();
    const background = new PIXI.tilemap.CompositeRectTileLayer();

    const foreground = new PIXI.tilemap.CompositeRectTileLayer();
    foreground.alpha = 0.5; // Set the layer alpha

    stage.addChild(background);
    stage.addChild(foreground);

    animate();

    background.addFrame(resources.atlas.textures["grass.png"], 0 * 32, 0);
    background.addFrame(resources.atlas.textures["grass.png"], 1 * 32, 0);
    background.addFrame(resources.atlas.textures["grass.png"], 2 * 32, 0);

    // You can also set the alpha value to a single tile
    foreground.addFrame(resources.atlas.textures["chest.png"], 0 * 32, 0).tileAlpha(0.5);
    foreground.addFrame(resources.atlas.textures["chest.png"], 1 * 32, 0);
    foreground.addFrame(resources.atlas.textures["chest.png"], 2 * 32, 0);
});

function animate() {
    requestAnimationFrame(animate);
    renderer.render(stage);
}
```

![iyvfidf](https://user-images.githubusercontent.com/1335948/86221469-3c9a2180-bb85-11ea-8da7-c6dca8b73ae6.png)


**Testing:**

Tested on macOS Chrome, Safari and Firefox both WebGL and Canvas.

**Why?**

Tiled allows to set alpha values for each layer. 
Having the ability to reflect that alpha in development is extremely useful to debug if, like me, you are implementing collision with a title layer.

![Screen Shot 2020-06-30 at 19 58 31](https://user-images.githubusercontent.com/1335948/86160703-6ebb6d00-bb0c-11ea-8287-94800fdeea18.png)

This can be also used to generate some cool effects like fog, for example.
As a bonus I added support to set alpha to a single title because I'm sure Pixi users will have a creative use case for it :)


**Conflicts:**

In case my other pull request gets merged (https://github.com/pixijs/pixi-tilemap/pull/87) this one is going to have tons of conflicts. Just give me a shout and I'll quickly fix them.