### PR TITLE
added typedefs to export in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/pixi-tilemap.es.js",
       "require": "./dist/pixi-tilemap.umd.js"
     }


### PR DESCRIPTION
typescript will complain about not being able to resolve the type defs without explicitly adding them to the `exports` section