### PR TITLE
Initialize texturesPerTilemap before calling tileset

### DIFF
--- a/src/CompositeTilemap.ts
+++ b/src/CompositeTilemap.ts
@@ -96,8 +96,8 @@ export class CompositeTilemap extends Container
     {
         super();
 
-        this.tileset(tileset);
         this.texturesPerTilemap = settings.TEXTURES_PER_TILEMAP;
+        this.tileset(tileset);
     }
 
     /**


### PR DESCRIPTION
because texturesPerTilemap is used in the tileset method.