### PR TITLE
Fixed incorrect projection

### DIFF
--- a/examples/demo/basic.js
+++ b/examples/demo/basic.js
@@ -125,5 +125,23 @@
         initialize();
     };
 
+    let panPos = undefined;
+
+    app.canvas.addEventListener('mousemove', (e) => {
+        if (!panPos) return;
+
+        app.stage.position.x += e.pageX - panPos.x;
+        app.stage.position.y += e.pageY - panPos.y;
+        panPos = { x: e.pageX, y: e.pageY };
+    });
+
+    app.canvas.addEventListener('mousedown', (e) => {
+        panPos = { x: e.pageX, y: e.pageY };
+    });
+
+    app.canvas.addEventListener('mouseup', (e) => {
+        panPos = undefined;
+    });
+
     runApp();
 })();

--- a/src/TilemapPipe.ts
+++ b/src/TilemapPipe.ts
@@ -173,8 +173,7 @@ export class TilemapPipe implements RenderPipe<Tilemap>, InstructionPipe<Tilemap
         let anim_frame = this.tileAnim;
         const { u_anim_frame } = pipe_uniforms.uniforms;
 
-        u_global.uProjectionMatrix.copyTo(u_proj_trans).append(u_global.uWorldTransformMatrix)
-            .append(tilemap.worldTransform);
+        u_global.uProjectionMatrix.copyTo(u_proj_trans).append(tilemap.worldTransform);
         if (tilemap.compositeParent)
         {
             anim_frame = (tilemap.parent as CompositeTilemap).tileAnim || anim_frame;


### PR DESCRIPTION
See issue #167

I think the issue was the world transform being applied twice here. Removing `.append(u_global.uWorldTransformMatrix)` seemed to fix it, the `tilemap.worldTransform` should already contain the `uWorldTransformMatrix`

I also added panning to the basic example to test this change. Can be removed.